### PR TITLE
Add `id` to global variables

### DIFF
--- a/R/AquaticLifeHistory.R
+++ b/R/AquaticLifeHistory.R
@@ -18,7 +18,7 @@ NULL
 
 utils::globalVariables(c("Age", "Pred", "Model", "AVG", "w.AVG", ".", "Estimate", 'high', "low",
                          'Maturity', 'N', 'Maturity.prop','Maturity.group', 'prop', 'na.omit',
-                         'term', 'Length', 'upp', 'Len.bin', 'Len.start', 'Len.fin', 'Maturity.group'))
+                         'term', 'Length', 'upp', 'Len.bin', 'Len.start', 'Len.fin', 'Maturity.group', 'id'))
 
 #' Length-at-age data for blacktip sharks
 #'


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package does one of two things:

- It re-exports `dplyr::id()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `id`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("id")`. In this case, you got lucky that dplyr exported `id()`, meaning that you did not need a global variable for `"id"`. Since we have removed `dplyr::id()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!